### PR TITLE
#14 더블클릭시 카메라 초기화 기능

### DIFF
--- a/src/components/origami.js
+++ b/src/components/origami.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 import { sizes } from '../three/Sizes';
-import { camera } from '../three/Camera';
+import { camera, initialCameraPosition } from '../three/Camera';
 import { controls } from '../three/Controls';
 import { ambientLight, directionalLight } from '../three/Lights';
 import { paper, borderVertices } from '../three/Paper';
@@ -137,5 +137,8 @@ window.addEventListener('resize', handleResize);
 window.addEventListener('mousemove', handleMouseMove);
 window.addEventListener('mousedown', handleMouseDown);
 window.addEventListener('mouseup', handleMouseUp);
+playCont.addEventListener('dblclick', () => {
+  camera.position.copy(initialCameraPosition);
+});
 
 MarkClosestVertexAnimate();

--- a/src/three/Camera.js
+++ b/src/three/Camera.js
@@ -2,11 +2,13 @@ import * as THREE from 'three';
 import { sizes } from './Sizes';
 
 const camera = new THREE.PerspectiveCamera(
-  75,
+  45,
   sizes.width / sizes.height,
   0.1,
   1000
 );
 camera.position.z = 3;
 
-export { camera };
+const initialCameraPosition = camera.position.clone();
+
+export { camera, initialCameraPosition };


### PR DESCRIPTION
## 📍 주요 변경사항

* 더블클릭할 시 초기 카메라 설정으로 돌아갑니다.
* 칸반 작성과 다르게 (paper에 intersecting중일 때는 더블클릭 먹지 않음) paper에 intersecting중일 때도 더블클릭으로 카메라를 초기화할 수 있게 했습니다.
* 카메라 초기 세팅 원근감 75 -> 45로 변경했습니다.
```javascript
const camera = new THREE.PerspectiveCamera(
  45,
  sizes.width / sizes.height,
  0.1,
  1000
);
camera.position.z = 3;
```

## 🔗 참고자료
 * #14 

## 작업 내용(to-do list)
[x] 종이 외 영역을 더블 클릭하면 카메라 초기화

# 주의사항


- [x]  PR 크기는 300-500줄로 하되 최대 1000줄 미만으로 합니다.
- [x]  conflict를 모두 해결하고 PR을 올려주세요
- [x]  위 해당사항을 모두 완료 후 PR을 올려주세요

# PR 전 체크리스트


- [x]  가장 최신 브랜치를 Pull 했습니다.
- [x]  base 브랜치명을 확인했습니다.
- [x]  코드 컨벤션을 모두 확인했습니다.
- [x]  브랜치 명을 확인했습니다.
- [x]  작업 중 dependency 변경사항이 있는 경우 [주의사항](https://www.notion.so/Client-4d424081e51242c1b19484c3461f631b?pvs=21)에 꼭 적어주세요!!
- [x]  위 해당사항을 모두 완료 후 PR을 올려주세요
