### PR TITLE
#11 접기 기능 구현 버그 픽스

### DIFF
--- a/src/components/modules/axisCalculations.js
+++ b/src/components/modules/axisCalculations.js
@@ -1,7 +1,13 @@
 import * as THREE from 'three';
 import { PAPER_BOUNDARY, DASH_SIZE } from '../../constants';
 
-export const calculateRotatedLine = (
+let axisPoints = {};
+
+const getAxisPoints = () => {
+  return axisPoints;
+};
+
+const calculateRotatedLine = (
   scene,
   mouseDownVertex,
   mouseUpVertex,
@@ -221,9 +227,20 @@ export const calculateRotatedLine = (
     scene.add(vertexIntervalRotatedBasedOnY);
   }
 
+  const startPoint = rotatedLineVertex.clampedStartBasedOnX
+    ? rotatedLineVertex.clampedStartBasedOnX
+    : rotatedLineVertex.clampedStartBasedOnY;
+  const endPoint = rotatedLineVertex.clampedEndBasedOnX
+    ? rotatedLineVertex.clampedEndBasedOnX
+    : rotatedLineVertex.clampedEndBasedOnY;
+
+  axisPoints = { startPoint, endPoint };
+
   return {
     vertexIntervalRotatedBasedOnX,
     vertexIntervalRotatedBasedOnY,
-    rotatedLineVertex,
+    axisPoints,
   };
 };
+
+export { getAxisPoints, calculateRotatedLine };

--- a/src/components/modules/findClosestVertex.js
+++ b/src/components/modules/findClosestVertex.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 
-export const findClosestVertex = (intersectPoint, borderVertices) => {
+const findClosestVertex = (intersectPoint, borderVertices) => {
   let minDistance = Infinity;
   let closestVertex = null;
   let closestVertexIndex = -1;
@@ -22,3 +22,5 @@ export const findClosestVertex = (intersectPoint, borderVertices) => {
 
   return { closestVertex, closestVertexIndex, minDistance };
 };
+
+export { findClosestVertex };

--- a/src/components/modules/foldingAnimation.js
+++ b/src/components/modules/foldingAnimation.js
@@ -1,7 +1,24 @@
 import * as THREE from 'three';
 
+import { camera } from '../../three/Camera';
 import { paper } from '../../three/Paper';
 import { Z_GAP } from '../../constants';
+
+const calculateFrontorBack = () => {
+  const cameraDirection = new THREE.Vector3();
+  camera.getWorldDirection(cameraDirection);
+
+  const paperNormal = new THREE.Vector3(0, 0, 1);
+  paperNormal.applyQuaternion(paper.quaternion);
+
+  const dotProduct = cameraDirection.dot(paperNormal);
+
+  if (dotProduct > 0) {
+    return -1;
+  } else {
+    return 1;
+  }
+};
 
 const getFoldDirection = (startPoint, endPoint, redMarker) => {
   const { x: x1, y: y1 } = startPoint;
@@ -40,6 +57,7 @@ const fold = (startPoint, endPoint, direction) => {
   const { x: x2, y: y2 } = endPoint;
 
   const inequality = getInequalityFunction(direction);
+  const frontOrBack = calculateFrontorBack();
 
   const m = (y2 - y1) / (x2 - x1);
   const c = y1 - m * x1;
@@ -51,7 +69,7 @@ const fold = (startPoint, endPoint, direction) => {
 
       if (inequality(vertex.x, x1)) {
         vertex.x = 2 * x1 - vertex.x;
-        vertex.z += Z_GAP;
+        vertex.z += Z_GAP * frontOrBack;
 
         allPositions.setXYZ(i, vertex.x, vertex.y, vertex.z);
       }
@@ -63,7 +81,7 @@ const fold = (startPoint, endPoint, direction) => {
 
       if (inequality(vertex.y, y1)) {
         vertex.y = 2 * y1 - vertex.y;
-        vertex.z += Z_GAP;
+        vertex.z += Z_GAP * frontOrBack;
 
         allPositions.setXYZ(i, vertex.x, vertex.y, vertex.z);
       }
@@ -83,7 +101,7 @@ const fold = (startPoint, endPoint, direction) => {
 
         vertex.x = 2 * ix - vertex.x;
         vertex.y = 2 * iy - vertex.y;
-        vertex.z += Z_GAP;
+        vertex.z += Z_GAP * frontOrBack;
 
         allPositions.setXYZ(i, vertex.x, vertex.y, vertex.z);
       }

--- a/src/components/modules/foldingAnimation.js
+++ b/src/components/modules/foldingAnimation.js
@@ -115,21 +115,13 @@ const fold = (startPoint, endPoint, direction) => {
   }
 
   AllFoldedFaces.push(nowFace);
-  console.log(AllFoldedFaces);
-
   allPositions.needsUpdate = true;
 };
 
-const foldingAnimation = (axis, redMarker) => {
-  const { rotatedLineVertex: borderVertex } = axis;
-  const startPoint = borderVertex.clampedStartBasedOnX
-    ? borderVertex.clampedStartBasedOnX
-    : borderVertex.clampedStartBasedOnY;
-  const endPoint = borderVertex.clampedEndBasedOnX
-    ? borderVertex.clampedEndBasedOnX
-    : borderVertex.clampedEndBasedOnY;
-
+const foldingAnimation = (axisPoints, redMarker) => {
+  const { startPoint, endPoint } = axisPoints;
   const direction = getFoldDirection(startPoint, endPoint, redMarker.position);
+
   fold(startPoint, endPoint, direction);
 };
 

--- a/src/components/modules/foldingAnimation.js
+++ b/src/components/modules/foldingAnimation.js
@@ -4,6 +4,8 @@ import { camera } from '../../three/Camera';
 import { paper } from '../../three/Paper';
 import { Z_GAP } from '../../constants';
 
+const AllFoldedFaces = [];
+
 const calculateFrontorBack = () => {
   const cameraDirection = new THREE.Vector3();
   camera.getWorldDirection(cameraDirection);
@@ -56,6 +58,7 @@ const fold = (startPoint, endPoint, direction) => {
   const { x: x1, y: y1 } = startPoint;
   const { x: x2, y: y2 } = endPoint;
 
+  const nowFace = [];
   const inequality = getInequalityFunction(direction);
   const frontOrBack = calculateFrontorBack();
 
@@ -71,6 +74,7 @@ const fold = (startPoint, endPoint, direction) => {
         vertex.x = 2 * x1 - vertex.x;
         vertex.z += Z_GAP * frontOrBack;
 
+        nowFace.push({ x: vertex.x, y: vertex.y, z: vertex.z });
         allPositions.setXYZ(i, vertex.x, vertex.y, vertex.z);
       }
     }
@@ -83,6 +87,7 @@ const fold = (startPoint, endPoint, direction) => {
         vertex.y = 2 * y1 - vertex.y;
         vertex.z += Z_GAP * frontOrBack;
 
+        nowFace.push({ x: vertex.x, y: vertex.y, z: vertex.z });
         allPositions.setXYZ(i, vertex.x, vertex.y, vertex.z);
       }
     }
@@ -103,10 +108,14 @@ const fold = (startPoint, endPoint, direction) => {
         vertex.y = 2 * iy - vertex.y;
         vertex.z += Z_GAP * frontOrBack;
 
+        nowFace.push({ x: vertex.x, y: vertex.y, z: vertex.z });
         allPositions.setXYZ(i, vertex.x, vertex.y, vertex.z);
       }
     }
   }
+
+  AllFoldedFaces.push(nowFace);
+  console.log(AllFoldedFaces);
 
   allPositions.needsUpdate = true;
 };

--- a/src/components/modules/makeVertices.js
+++ b/src/components/modules/makeVertices.js
@@ -1,10 +1,14 @@
+import { getAxisPoints } from './axisCalculations';
+
+const borderPoints = [];
+
 const interpolatePoints = (start, end, numPoints) => {
   const points = [];
   const deltaX = (end.x - start.x) / (numPoints + 1);
   const deltaY = (end.y - start.y) / (numPoints + 1);
   const deltaZ = (end.z - start.z) / (numPoints + 1);
 
-  points.push(start); // Add the starting corner
+  points.push(start);
 
   for (let i = 1; i <= numPoints; i++) {
     points.push({
@@ -17,9 +21,7 @@ const interpolatePoints = (start, end, numPoints) => {
   return points;
 };
 
-const generateBorderPoints = (corners, pointsPerEdge) => {
-  const borderPoints = [];
-
+const generateBorderPoints = (corners, pointsPerEdge = 9) => {
   for (let i = 0; i < corners.length; i++) {
     const start = corners[i];
     const end = corners[(i + 1) % corners.length];
@@ -30,4 +32,23 @@ const generateBorderPoints = (corners, pointsPerEdge) => {
   return borderPoints;
 };
 
-export { generateBorderPoints };
+const findBorderVertices = () => {
+  const corners = [
+    { x: 1.5, y: 1.5, z: 0 },
+    { x: -1.5, y: 1.5, z: 0 },
+    { x: -1.5, y: -1.5, z: 0 },
+    { x: 1.5, y: -1.5, z: 0 },
+  ];
+
+  return corners;
+};
+
+const addVertices = () => {
+  const { startPoint, endPoint } = getAxisPoints();
+  generateBorderPoints([startPoint, endPoint]);
+};
+
+const corners = findBorderVertices();
+const borderVertices = generateBorderPoints(corners);
+
+export { borderVertices, addVertices };

--- a/src/components/modules/origami.js
+++ b/src/components/modules/origami.js
@@ -5,12 +5,13 @@ import { sizes } from '../../three/Sizes';
 import { camera, initializeCamera } from '../../three/Camera';
 import { controls } from '../../three/Controls';
 import { ambientLight, directionalLight } from '../../three/Lights';
-import { paper, borderVertices } from '../../three/Paper';
+import { paper } from '../../three/Paper';
 import { renderer, finishRenderer } from '../../three/Renderer';
 
 import { findClosestVertex } from './findClosestVertex';
 import { calculateRotatedLine } from './axisCalculations';
 import { foldingAnimation } from './foldingAnimation';
+import { borderVertices, addVertices } from './makeVertices';
 
 import {
   POINTS_MARKER_COLOR,
@@ -29,6 +30,7 @@ const scene = new THREE.Scene();
 scene.add(paper);
 scene.add(ambientLight);
 scene.add(directionalLight);
+
 const raycaster = new THREE.Raycaster();
 const mouse = new THREE.Vector2();
 
@@ -113,7 +115,7 @@ const handleMouseUp = () => {
       ).closestVertex;
 
       if (closestVertex) {
-        const rotatedLines = calculateRotatedLine(
+        const axis = calculateRotatedLine(
           scene,
           clickedRedMarker.position,
           closestVertex,
@@ -121,10 +123,8 @@ const handleMouseUp = () => {
           vertexIntervalRotatedBasedOnY
         );
 
-        vertexIntervalRotatedBasedOnX =
-          rotatedLines.vertexIntervalRotatedBasedOnX;
-        vertexIntervalRotatedBasedOnY =
-          rotatedLines.vertexIntervalRotatedBasedOnY;
+        vertexIntervalRotatedBasedOnX = axis.vertexIntervalRotatedBasedOnX;
+        vertexIntervalRotatedBasedOnY = axis.vertexIntervalRotatedBasedOnY;
         vertexIntervalRotatedBasedOnX
           ? scene.add(vertexIntervalRotatedBasedOnX)
           : null;
@@ -132,7 +132,8 @@ const handleMouseUp = () => {
           ? scene.add(vertexIntervalRotatedBasedOnY)
           : null;
 
-        foldingAnimation(rotatedLines, clickedRedMarker);
+        foldingAnimation(axis.axisPoints, clickedRedMarker);
+        addVertices();
       }
     }
   }
@@ -225,25 +226,5 @@ window.addEventListener('mousemove', handleMouseMove);
 window.addEventListener('mousedown', handleMouseDown);
 window.addEventListener('mouseup', handleMouseUp);
 playCont.addEventListener('dblclick', initializeCamera);
-// playCont.addEventListener('click', () => {
-//   /**
-//    * 카메라가 보는 paper 방향 판별
-//    *
-//    */
-
-//   // 클릭 시 카메라가 보고 있는 방향 판별
-//   raycaster.setFromCamera(mouse, camera);
-//   const intersects = raycaster.intersectObject(paper);
-
-//   if (intersects.length > 0) {
-//     const face = intersects[0].face;
-//     console.log9
-//     if (face.normal.z > 0) {
-//       console.log('앞면');
-//     } else {
-//       console.log('뒷면');
-//     }
-//   }
-// });
 
 markClosestVertexAnimate();

--- a/src/components/modules/origami.js
+++ b/src/components/modules/origami.js
@@ -101,7 +101,7 @@ const handleMouseUp = () => {
     showToastMessages(TOAST_MESSAGE.SAME_POSITION);
   } else if (!pointsMarker.visible && clickedRedMarker.visible) {
     showToastMessages(TOAST_MESSAGE.NO_POINTMARKER);
-  } else {
+  } else if (pointsMarker.visible && clickedRedMarker.visible) {
     raycaster.setFromCamera(mouse, camera);
     const intersects = raycaster.intersectObject(paper);
 
@@ -225,5 +225,25 @@ window.addEventListener('mousemove', handleMouseMove);
 window.addEventListener('mousedown', handleMouseDown);
 window.addEventListener('mouseup', handleMouseUp);
 playCont.addEventListener('dblclick', initializeCamera);
+// playCont.addEventListener('click', () => {
+//   /**
+//    * 카메라가 보는 paper 방향 판별
+//    *
+//    */
+
+//   // 클릭 시 카메라가 보고 있는 방향 판별
+//   raycaster.setFromCamera(mouse, camera);
+//   const intersects = raycaster.intersectObject(paper);
+
+//   if (intersects.length > 0) {
+//     const face = intersects[0].face;
+//     console.log9
+//     if (face.normal.z > 0) {
+//       console.log('앞면');
+//     } else {
+//       console.log('뒷면');
+//     }
+//   }
+// });
 
 markClosestVertexAnimate();

--- a/src/components/modules/origami.js
+++ b/src/components/modules/origami.js
@@ -12,7 +12,11 @@ import { findClosestVertex } from './findClosestVertex';
 import { calculateRotatedLine } from './axisCalculations';
 import { foldingAnimation } from './foldingAnimation';
 
-import { POINTS_MARKER_COLOR, RED_MARKER_COLOR } from '../../constants';
+import {
+  POINTS_MARKER_COLOR,
+  RED_MARKER_COLOR,
+  TOAST_MESSAGE,
+} from '../../constants';
 
 const section = document.querySelector('section');
 const playCont = document.querySelector('.play-cont');
@@ -47,6 +51,15 @@ scene.add(pointsMarker);
 
 const clickedRedMarker = createPointsMarker(RED_MARKER_COLOR);
 scene.add(clickedRedMarker);
+
+const showToastMessages = text => {
+  foldFailToastMessage.innerText = text;
+  foldFailToastMessage.classList.add('active');
+
+  setTimeout(() => {
+    foldFailToastMessage.classList.remove('active');
+  }, 2000);
+};
 
 const updateSizesAndCamera = cont => {
   const rect = cont.getBoundingClientRect();
@@ -85,20 +98,9 @@ const handleMouseUp = () => {
   controls.enabled = true;
 
   if (areMarkersAtSamePosition && clickedRedMarker.visible) {
-    foldFailToastMessage.innerText = '마우스를 접을 곳으로 이동해 주세요!';
-    foldFailToastMessage.classList.add('active');
-
-    setTimeout(() => {
-      foldFailToastMessage.classList.remove('active');
-    }, 2000);
+    showToastMessages(TOAST_MESSAGE.SAME_POSITION);
   } else if (!pointsMarker.visible && clickedRedMarker.visible) {
-    foldFailToastMessage.innerText =
-      '꼭짓점이 접을 수 있는 선분에 닿아야 합니다!';
-    foldFailToastMessage.classList.add('active');
-
-    setTimeout(() => {
-      foldFailToastMessage.classList.remove('active');
-    }, 2000);
+    showToastMessages(TOAST_MESSAGE.NO_POINTMARKER);
   } else {
     raycaster.setFromCamera(mouse, camera);
     const intersects = raycaster.intersectObject(paper);

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -10,6 +10,11 @@ const PAPER_BOUNDARY = 1.5;
 const DASH_SIZE = 0.02;
 const Z_GAP = 0.02;
 
+const TOAST_MESSAGE = {
+  SAME_POSITION: '마우스를 접을 곳으로 이동해 주세요!',
+  NO_POINTMARKER: '꼭짓점이 접을 수 있는 선분에 닿아야 합니다!',
+};
+
 export {
   POINTS_MARKER_COLOR,
   RED_MARKER_COLOR,
@@ -18,4 +23,5 @@ export {
   PAPER_BOUNDARY,
   DASH_SIZE,
   Z_GAP,
+  TOAST_MESSAGE,
 };

--- a/src/three/Paper.js
+++ b/src/three/Paper.js
@@ -1,6 +1,4 @@
 import * as THREE from 'three';
-import { generateBorderPoints } from '../components/modules/makeVertices';
-
 import { PAPERCOLORS, SEGMENT_NUM } from '../constants';
 
 const getRandomColors = length => {
@@ -51,18 +49,4 @@ const material = new THREE.ShaderMaterial({
 
 const paper = new THREE.Mesh(geometry, material);
 
-const findBorderVertices = () => {
-  const corners = [
-    { x: 1.5, y: 1.5, z: 0 },
-    { x: -1.5, y: 1.5, z: 0 },
-    { x: -1.5, y: -1.5, z: 0 },
-    { x: 1.5, y: -1.5, z: 0 },
-  ];
-
-  return corners;
-};
-
-const corners = findBorderVertices();
-const borderVertices = generateBorderPoints(corners, 9);
-
-export { paper, borderVertices };
+export { paper };

--- a/src/three/Paper.js
+++ b/src/three/Paper.js
@@ -14,7 +14,9 @@ const getRandomColors = length => {
   return [frontColorIndex, backColorIndex];
 };
 
-const [frontColorIndex, backColorIndex] = getRandomColors(PAPERCOLORS.length);
+const [frontColorIndex, backColorIndex] = getRandomColors(
+  PAPERCOLORS.length - 1
+);
 const frontColor = PAPERCOLORS[frontColorIndex];
 const backColor = PAPERCOLORS[backColorIndex];
 


### PR DESCRIPTION
## 📍 주요 변경사항
- 드래그하지 않아도 접히는 버그 수정했습니다.
- paper의 랜덤 컬러 지정하지 않은 색상으로 나오는 것 수정했습니다.
- 접을 때 접을 수 있는 기준 (파란 점) 도 같이 움직이도록 수정했습니다.
- 바라보는 위치에 따라 접히는 z 축 방향 추가했습니다.

## 🔗 참고자료

- #11 

## 💡 중점적으로 봐주었으면 하는 부분

- 현재 여러 번 접었을 때 뒷면, 앞면이 뒤집혀서 나오는 버그 있습니다.
- 하나의 geometry로 접다보니 세그먼트가 꼬이면서 일어나는 현상이라고 예상중인데 확실하지않습니다.

# 주의사항

- [x] PR 크기는 300-500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요.
- [x] 위 해당사항을 모두 완료 후 PR을 올려주세요.

# PR 전 체크리스트

- [x] 가장 최신 브랜치를 Pull 했습니다.
- [x] base 브랜치명을 확인했습니다.
- [x] 코드 컨벤션을 모두 확인했습니다.
- [x] 브랜치 명을 확인했습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 주의사항에 꼭 적어주세요!
- [x] 위 해당사항을 모두 완료 후 PR을 올려주세요.
