### PR TITLE
#16 뒤로가기, 앞으로가기 기능 구현

### DIFF
--- a/play.html
+++ b/play.html
@@ -61,11 +61,15 @@
             <li>
               <button
                 class="circle-button rollback-button button-purple"
+                id="prevButton"
+                disabled
               ></button>
             </li>
             <li>
               <button
                 class="circle-button commit-button button-purple"
+                id="nextButton"
+                disabled
               ></button>
             </li>
           </ul>

--- a/src/components/modules/foldingAnimation.js
+++ b/src/components/modules/foldingAnimation.js
@@ -1,6 +1,7 @@
 import { paper } from '../../three/Paper';
 import { foldingVertexPosition } from './foldingVertexPosition';
 import { getFoldingDirection } from './getFoldingDirection';
+import { borderVertices } from './makeVertices';
 
 const foldingAnimation = (axisPoints, redMarker, isFolding) => {
   const { startPoint, endPoint } = axisPoints;
@@ -12,6 +13,13 @@ const foldingAnimation = (axisPoints, redMarker, isFolding) => {
 
   foldingVertexPosition(
     paper.geometry.attributes.position,
+    startPoint,
+    endPoint,
+    direction,
+    isFolding
+  );
+  foldingVertexPosition(
+    borderVertices,
     startPoint,
     endPoint,
     direction,

--- a/src/components/modules/makeVertices.js
+++ b/src/components/modules/makeVertices.js
@@ -48,7 +48,11 @@ const addVertices = () => {
   generateBorderPoints([startPoint, endPoint]);
 };
 
-const corners = findBorderVertices();
-const borderVertices = generateBorderPoints(corners);
+const changeBorderVertices = newData => {
+  borderVertices = newData;
+};
 
-export { borderVertices, addVertices };
+const corners = findBorderVertices();
+let borderVertices = generateBorderPoints(corners);
+
+export { borderVertices, addVertices, changeBorderVertices };

--- a/src/components/modules/makeVertices.js
+++ b/src/components/modules/makeVertices.js
@@ -1,6 +1,7 @@
 import { getAxisPoints } from './axisCalculations';
 
 const borderPoints = [];
+let borderVertices = [];
 
 const interpolatePoints = (start, end, numPoints) => {
   const points = [];
@@ -27,6 +28,7 @@ const generateBorderPoints = (corners, pointsPerEdge = 9) => {
     const end = corners[(i + 1) % corners.length];
     const interpolatedPoints = interpolatePoints(start, end, pointsPerEdge);
     borderPoints.push(...interpolatedPoints);
+    borderVertices.push(...interpolatedPoints);
   }
 
   return borderPoints;
@@ -53,6 +55,6 @@ const changeBorderVertices = newData => {
 };
 
 const corners = findBorderVertices();
-let borderVertices = generateBorderPoints(corners);
+borderVertices = generateBorderPoints(corners);
 
 export { borderVertices, addVertices, changeBorderVertices };

--- a/src/components/modules/origami.js
+++ b/src/components/modules/origami.js
@@ -15,6 +15,7 @@ import { borderVertices, addVertices } from './makeVertices';
 import { getFoldingDirection } from './getFoldingDirection';
 import { foldingVertexPosition } from './foldingVertexPosition';
 import { prevFoldingArea } from './prevFoldingArea';
+import { activeButtons } from './prevNextButtons';
 
 import {
   POINTS_MARKER_COLOR,
@@ -28,6 +29,9 @@ const finishCont = document.querySelector('.complete-scene');
 const finishButton = document.querySelector('.finish-button');
 const completeCont = document.querySelector('.complete-cont');
 const foldFailToastMessage = document.querySelector('#foldFailToastMessage');
+
+const prevButton = document.querySelector('#prevButton');
+const nextButton = document.querySelector('#nextButton');
 
 const scene = new THREE.Scene();
 scene.add(paper);
@@ -293,6 +297,7 @@ const handleMouseUp = () => {
 
         foldingAnimation(axis.axisPoints, clickedRedMarker, true);
         addVertices();
+        activeButtons(prevButton, nextButton);
       }
     }
   }
@@ -344,17 +349,6 @@ const markClosestVertexAnimate = () => {
   requestAnimationFrame(markClosestVertexAnimate);
 };
 
-finishButton.addEventListener('click', () => {
-  isFinished = true;
-  completeCont.classList.remove('none');
-  section.classList.add('active');
-  launchConfetti();
-  confettiIntervalId = setInterval(launchConfetti, 3500);
-  renderer.clear();
-  handleResize();
-  initializeCamera();
-});
-
 const launchConfetti = () => {
   if (isFinished) {
     confetti({
@@ -381,6 +375,9 @@ finishButton.addEventListener('click', () => {
   handleResize();
   initializeCamera();
 });
+
+prevButton.addEventListener('click', () => {});
+nextButton.addEventListener('click', () => {});
 
 window.addEventListener('resize', handleResize);
 window.addEventListener('mousemove', handleMouseMove);

--- a/src/components/modules/origami.js
+++ b/src/components/modules/origami.js
@@ -305,7 +305,7 @@ const handleMouseUp = () => {
           paper: new Float32Array(
             paper.geometry.attributes.position.array.slice()
           ),
-          borderVertices: borderVertices.slice(),
+          borderVertices: JSON.parse(JSON.stringify(borderVertices)),
         });
         foldingAnimation(axis.axisPoints, clickedRedMarker, true);
         addVertices();

--- a/src/components/modules/origami.js
+++ b/src/components/modules/origami.js
@@ -16,6 +16,12 @@ import { getFoldingDirection } from './getFoldingDirection';
 import { foldingVertexPosition } from './foldingVertexPosition';
 import { prevFoldingArea } from './prevFoldingArea';
 import { activeButtons } from './prevNextButtons';
+import {
+  checkActiveButtons,
+  changeToPrevFold,
+  changeToNextFold,
+  saveFoldHistory,
+} from './prevNextButtons';
 
 import {
   POINTS_MARKER_COLOR,
@@ -295,9 +301,16 @@ const handleMouseUp = () => {
           ? scene.add(vertexIntervalRotatedBasedOnY)
           : null;
 
+        saveFoldHistory({
+          paper: new Float32Array(
+            paper.geometry.attributes.position.array.slice()
+          ),
+          borderVertices: borderVertices.slice(),
+        });
         foldingAnimation(axis.axisPoints, clickedRedMarker, true);
         addVertices();
-        activeButtons(prevButton, nextButton);
+
+        checkActiveButtons(prevButton, nextButton);
       }
     }
   }
@@ -376,8 +389,14 @@ finishButton.addEventListener('click', () => {
   initializeCamera();
 });
 
-prevButton.addEventListener('click', () => {});
-nextButton.addEventListener('click', () => {});
+prevButton.addEventListener('click', () => {
+  changeToPrevFold();
+  checkActiveButtons(prevButton, nextButton);
+});
+nextButton.addEventListener('click', () => {
+  changeToNextFold();
+  checkActiveButtons(prevButton, nextButton);
+});
 
 window.addEventListener('resize', handleResize);
 window.addEventListener('mousemove', handleMouseMove);

--- a/src/components/modules/origami.js
+++ b/src/components/modules/origami.js
@@ -15,7 +15,7 @@ import { borderVertices, addVertices } from './makeVertices';
 import { getFoldingDirection } from './getFoldingDirection';
 import { foldingVertexPosition } from './foldingVertexPosition';
 import { prevFoldingArea } from './prevFoldingArea';
-import { activeButtons } from './prevNextButtons';
+
 import {
   checkActiveButtons,
   changeToPrevFold,

--- a/src/components/modules/prevNextButtons.js
+++ b/src/components/modules/prevNextButtons.js
@@ -20,9 +20,9 @@ const changeToPrevFold = () => {
       borderVertices: currentBorderVertices,
     });
 
-    const lastIndex = prevHistory.pop();
-    const prevPositions = lastIndex.paper;
-    const prevVertices = lastIndex.borderVertices;
+    const lastHistory = prevHistory.pop();
+    const prevPositions = lastHistory.paper;
+    const prevVertices = lastHistory.borderVertices;
 
     paper.geometry.setAttribute(
       'position',
@@ -42,9 +42,9 @@ const changeToNextFold = () => {
       borderVertices: currentBorderVertices,
     });
 
-    const lastIndex = nextHistory.pop();
-    const nextPositions = lastIndex.paper;
-    const nextVertices = lastIndex.borderVertices;
+    const lastHistory = nextHistory.pop();
+    const nextPositions = lastHistory.paper;
+    const nextVertices = lastHistory.borderVertices;
 
     paper.geometry.setAttribute(
       'position',

--- a/src/components/modules/prevNextButtons.js
+++ b/src/components/modules/prevNextButtons.js
@@ -22,11 +22,13 @@ const changeToPrevFold = () => {
 
     const lastIndex = prevHistory.pop();
     const prevPositions = lastIndex.paper;
+    const prevVertices = lastIndex.borderVertices;
 
     paper.geometry.setAttribute(
       'position',
       new THREE.BufferAttribute(prevPositions, 3)
     );
+    changeBorderVertices(prevVertices);
   }
 };
 
@@ -42,11 +44,13 @@ const changeToNextFold = () => {
 
     const lastIndex = nextHistory.pop();
     const nextPositions = lastIndex.paper;
+    const nextVertices = lastIndex.borderVertices;
 
     paper.geometry.setAttribute(
       'position',
       new THREE.BufferAttribute(nextPositions, 3)
     );
+    changeBorderVertices(nextVertices);
   }
 };
 

--- a/src/components/modules/prevNextButtons.js
+++ b/src/components/modules/prevNextButtons.js
@@ -1,0 +1,14 @@
+const foldedHistoryStack = [];
+const foldedHistoryQueue = [];
+
+const activeButtons = (prev, next) => {
+  if (foldedHistoryStack.length) {
+    prev.disabled = false;
+  }
+
+  if (foldedHistoryQueue.length) {
+    next.disabled = false;
+  }
+};
+
+export { foldedHistoryStack, foldedHistoryQueue, activeButtons };

--- a/src/components/modules/prevNextButtons.js
+++ b/src/components/modules/prevNextButtons.js
@@ -1,14 +1,63 @@
-const foldedHistoryStack = [];
-const foldedHistoryQueue = [];
+import * as THREE from 'three';
+import { paper } from '../../three/Paper';
+import { borderVertices, changeBorderVertices } from './makeVertices';
 
-const activeButtons = (prev, next) => {
-  if (foldedHistoryStack.length) {
-    prev.disabled = false;
-  }
+const prevHistory = [];
+const nextHistory = [];
 
-  if (foldedHistoryQueue.length) {
-    next.disabled = false;
+const saveFoldHistory = history => {
+  prevHistory.push(history);
+  nextHistory.length = 0;
+};
+
+const changeToPrevFold = () => {
+  if (prevHistory.length > 0) {
+    const currentPositions = paper.geometry.attributes.position.array.slice();
+    const currentBorderVertices = borderVertices.slice();
+
+    nextHistory.push({
+      paper: currentPositions,
+      borderVertices: currentBorderVertices,
+    });
+
+    const lastIndex = prevHistory.pop();
+    const prevPositions = lastIndex.paper;
+
+    paper.geometry.setAttribute(
+      'position',
+      new THREE.BufferAttribute(prevPositions, 3)
+    );
   }
 };
 
-export { foldedHistoryStack, foldedHistoryQueue, activeButtons };
+const changeToNextFold = () => {
+  if (nextHistory.length > 0) {
+    const currentPositions = paper.geometry.attributes.position.array.slice();
+    const currentBorderVertices = [...borderVertices];
+
+    prevHistory.push({
+      paper: currentPositions,
+      borderVertices: currentBorderVertices,
+    });
+
+    const lastIndex = nextHistory.pop();
+    const nextPositions = lastIndex.paper;
+
+    paper.geometry.setAttribute(
+      'position',
+      new THREE.BufferAttribute(nextPositions, 3)
+    );
+  }
+};
+
+const checkActiveButtons = (prev, next) => {
+  prev.disabled = prevHistory.length === 0;
+  next.disabled = nextHistory.length === 0;
+};
+
+export {
+  checkActiveButtons,
+  saveFoldHistory,
+  changeToPrevFold,
+  changeToNextFold,
+};

--- a/src/styles/common.css
+++ b/src/styles/common.css
@@ -85,8 +85,13 @@ p {
   opacity: 50%;
 }
 
-.button-purple:hover {
+.button-purple:not(:disabled):hover {
   opacity: 100%;
+}
+
+.button-purple:disabled {
+  background-color: #838383;
+  cursor: default;
 }
 
 .circle-button {


### PR DESCRIPTION
## 📍 주요 변경사항

- 접기 기록에 대한 뒤로가기 , 앞으로가기 기능을 구현했습니다.
- 접힌 면의 정점들과 꼭짓점(borderVertices)에 대한 history를 관리합니다.

## 🔗 참고자료

- #16 

## 작업 내용(to-do list)

- [x] 앞으로 갈 단계가 없다면 앞으로가기 버튼 비활성화
- [x] 뒤로 갈 단계가 없다면 뒤로가기 버튼 비활성화

- [x]  실행된 접기 단계가 있다면 클릭 시 전 단계로 되돌아감 (카메라는 그대로)
- [x] 접힌 히스토리를 담고 있는 배열의 마지막 요소를 pop하여 렌더링(pop 한 부분을 앞으로가기 기능을 위해 stack에 저장해 둠)
- [x] 되돌리기 후 앞으로가기 버튼 클릭하면 다시 접어진 상태로 원상복구
- [x] 앞으로가기 버튼 클릭시 stack에 쌓여있던 것을 하나씩 다시 붙혀줌
- [x] 다시 접기를 하였을 경우 앞으로가기 stack을 초기화하여 앞으로가기 버튼 비활성화

# Remarks

- 기타 특이사항
- -한 면씩 접을 수 있도록하는 기능 추가로 작업하겠습니다.

# 주의사항

- [x] PR 크기는 300-500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요.
- [x] 위 해당사항을 모두 완료 후 PR을 올려주세요.

# PR 전 체크리스트

- [x] 가장 최신 브랜치를 Pull 했습니다.
- [x] base 브랜치명을 확인했습니다.
- [x] 코드 컨벤션을 모두 확인했습니다.
- [x] 브랜치 명을 확인했습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 주의사항에 꼭 적어주세요!
- [x] 위 해당사항을 모두 완료 후 PR을 올려주세요.
