### PR TITLE
Fix: 캔버스 크기 조정 및 z-index 조정

### DIFF
--- a/src/components/ui/GuideSlide.jsx
+++ b/src/components/ui/GuideSlide.jsx
@@ -33,6 +33,7 @@ const GuideWrap = styled.div`
   position: absolute;
   top: 39px;
   left: 57px;
+  z-index: 20;
   padding: 16px 60px;
   border-radius: 30px;
   background-color: rgba(255, 255, 255, 0.5);

--- a/src/components/ui/ModeSidebar.jsx
+++ b/src/components/ui/ModeSidebar.jsx
@@ -9,7 +9,7 @@ const SidebarContainer = styled.aside`
   width: ${({ $isVisible }) => ($isVisible ? '269px' : '0px')};
   height: 96%;
   opacity: ${({ $isVisible }) => ($isVisible ? '1' : '0')};
-  z-index: 10;
+  z-index: 30;
   overflow: hidden;
   box-sizing: border-box;
   padding: 30px 0 0 0;

--- a/src/pages/PlayPage.jsx
+++ b/src/pages/PlayPage.jsx
@@ -95,6 +95,7 @@ const PlayGuide = styled.div`
   position: absolute;
   top: 39px;
   right: 57px;
+  z-index: 20;
   padding: 16px 20px;
   border-radius: 10px;
   background-color: rgba(255, 255, 255, 0.5);
@@ -145,9 +146,9 @@ const PlayPage = () => {
 
   return (
     <MainContainer>
-      <PaperCanvas />
       <SectionContainer>
         {mode && <GuideSlide />}
+        <PaperCanvas />
         <PlayGuide>
           <PlayGuideP>
             <PlayGuideSpan>카메라 정면:</PlayGuideSpan> 빈 영역 더블클릭 하세요


### PR DESCRIPTION
## 📍 주요 변경사항

- canvas 크기 조정

## 🔗 참고자료
<img width="500" alt="image" src="https://github.com/user-attachments/assets/d13db1aa-19f3-47cb-b2a9-b195a02081d2">

캔버스가 play화면보다 더 크게 설정되어 종이가 밖으로 나가는 현상 수정

3D 종이가 툴팁 및 가이드 가려짐 현상 수정

<img width="400" alt="image" src="https://github.com/user-attachments/assets/9666b696-a82a-42f9-8c8d-5c147d30481f">
<img width="400" alt="image" src="https://github.com/user-attachments/assets/9de6dd67-7bd8-43e9-b67f-63652bdd16f2">

종이가 커졌을 때, GuideSlide 및 툴팁 가려짐 현상 수정

## 작업 내용(to-do list)

- [x] 캔버스가 play화면보다 더 크게 설정되어 종이가 밖으로 나가는 현상 수정
- [x] 종이가 커졌을 때, GuideSlide 및 툴팁 가려짐 현상 수정
- [x] 3D 종이가 툴팁 및 가이드 가려짐 현상 수정

# 주의사항

- [x] PR 크기는 300-500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요.
- [x] 위 해당사항을 모두 완료 후 PR을 올려주세요.

# PR 전 체크리스트

- [x] 가장 최신 브랜치를 Pull 했습니다.
- [x] base 브랜치명을 확인했습니다.
- [x] 코드 컨벤션을 모두 확인했습니다.
- [x] 브랜치 명을 확인했습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 주의사항에 꼭 적어주세요!
- [x] 위 해당사항을 모두 완료 후 PR을 올려주세요.
