### PR TITLE
Feat: Gallery 페이지 모달창 3D 렌더링 및 share 기능 구현

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -34,5 +34,20 @@ export default [
         { allowConstantExport: true },
       ],
     },
+    'react/no-unknown-property': [
+      'error',
+      {
+        ignore: [
+          'attach',
+          'args',
+          'color',
+          'rotation',
+          'position',
+          'scale',
+          'geometry',
+          'material',
+        ],
+      },
+    ],
   },
 ];

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="icon" href="/public/favicon.ico" />
+    <link rel="icon" href="/favicon.ico" />
     <link rel="stylesheet" href="./src/assets/css/common.css" />
     <title>Origami-V2</title>
   </head>

--- a/src/components/three/OrigamiCanvas.jsx
+++ b/src/components/three/OrigamiCanvas.jsx
@@ -1,0 +1,54 @@
+import { useEffect, useRef } from 'react';
+import { Canvas } from '@react-three/fiber';
+import { OrbitControls } from '@react-three/drei';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import * as THREE from 'three';
+
+const CanvasContainer = styled.div`
+  width: 100%;
+  height: 100%;
+`;
+
+const Scene = ({ positions }) => {
+  const meshRef = useRef();
+
+  useEffect(() => {
+    if (!positions.length || !meshRef.current) return;
+
+    const geometry = new THREE.BufferGeometry();
+    const vertices = new Float32Array(positions.flat());
+    geometry.setAttribute('position', new THREE.BufferAttribute(vertices, 3));
+    geometry.computeVertexNormals();
+    meshRef.current.geometry = geometry;
+  }, [positions]);
+
+  return (
+    <mesh ref={meshRef}>
+      <meshBasicMaterial wireframe color="blue" />
+    </mesh>
+  );
+};
+
+Scene.propTypes = {
+  positions: PropTypes.array.isRequired,
+};
+
+const OrigamiCanvas = ({ positions }) => {
+  return (
+    <CanvasContainer>
+      <Canvas>
+        <ambientLight intensity={0.5} />
+        <directionalLight position={[1, 1, 1]} intensity={0.5} />
+        <Scene positions={positions} />
+        <OrbitControls enableDamping />
+      </Canvas>
+    </CanvasContainer>
+  );
+};
+
+OrigamiCanvas.propTypes = {
+  positions: PropTypes.array.isRequired,
+};
+
+export default OrigamiCanvas;

--- a/src/components/ui/GalleryModal.jsx
+++ b/src/components/ui/GalleryModal.jsx
@@ -1,3 +1,6 @@
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { fetchUserPositions } from '../../utils/getUserService';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import closeIcon from '../../assets/img/close.png';
@@ -5,6 +8,8 @@ import shareIcon from '../../assets/img/share.png';
 
 const ModalWrap = styled.div`
   position: absolute;
+  top: 0;
+  left: 0%;
   width: 100vw;
   height: 100vh;
   background-color: rgba(0, 0, 0, 0.4);
@@ -29,6 +34,11 @@ const ModalImg = styled.div`
   width: 300px;
   height: 300px;
   background-color: #e8e8e8;
+
+  img {
+    width: 100%;
+    height: auto;
+  }
 `;
 
 const ModalText = styled.h3`
@@ -76,25 +86,44 @@ const ShareButton = styled.span`
   }
 `;
 
-const GalleryModal = ({ onClick }) => {
+const GalleryModal = ({ onClick, data }) => {
+  const [searchParams] = useSearchParams();
+  const id = searchParams.get('id');
+  const [positions, setPositions] = useState([]);
+
+  const selectedItem = data.find(item => item.id === id);
+
+  useEffect(() => {
+    const getUserpositions = async () => {
+      setPositions(await fetchUserPositions(id));
+    };
+
+    getUserpositions();
+  }, [id]);
+
   return (
-    <ModalWrap>
-      <Modal>
-        <CloseButton onClick={onClick}>
-          <img src={closeIcon} alt="닫는버튼" />
-        </CloseButton>
-        <ModalImg></ModalImg>
-        <ModalText>모달입니다</ModalText>
-        <ShareButton>
-          <img src={shareIcon} alt="공유버튼" />
-        </ShareButton>
-      </Modal>
-    </ModalWrap>
+    <div>
+      <ModalWrap>
+        <Modal>
+          <CloseButton onClick={onClick}>
+            <img src={closeIcon} alt="닫는버튼" />
+          </CloseButton>
+          <ModalImg>
+            <img src={selectedItem.thumbnail} alt="종이접기 이미지" />
+          </ModalImg>
+          <ModalText>{selectedItem.nickname}</ModalText>
+          <ShareButton>
+            <img src={shareIcon} alt="공유버튼" />
+          </ShareButton>
+        </Modal>
+      </ModalWrap>
+    </div>
   );
 };
 
 GalleryModal.propTypes = {
   onClick: PropTypes.func,
+  data: PropTypes.array,
 };
 
 export default GalleryModal;

--- a/src/components/ui/GalleryModal.jsx
+++ b/src/components/ui/GalleryModal.jsx
@@ -1,7 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { fetchUserPositions } from '../../utils/getUserService';
+import copyURL from '../../utils/copyURL';
 import OrigamiCanvas from '../../components/three/OrigamiCanvas';
+import ToastMessage from './ToastMessage';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import closeIcon from '../../assets/img/close.png';
@@ -80,6 +82,7 @@ const GalleryModal = ({ onClick, data }) => {
   const [searchParams] = useSearchParams();
   const id = searchParams.get('id');
   const [positions, setPositions] = useState([]);
+  const [toastMessage, setToastMessage] = useState('');
 
   const selectedItem = data.find(item => item.id === id);
 
@@ -91,6 +94,11 @@ const GalleryModal = ({ onClick, data }) => {
     getUserpositions();
   }, [id]);
 
+  const handleCopyURL = async () => {
+    const message = await copyURL();
+    setToastMessage(message);
+  };
+
   return (
     <div>
       <ModalWrap>
@@ -100,11 +108,17 @@ const GalleryModal = ({ onClick, data }) => {
           </CloseButton>
           <OrigamiCanvas positions={positions} />
           <ModalText>{selectedItem.nickname}</ModalText>
-          <ShareButton>
+          <ShareButton onClick={handleCopyURL}>
             <img src={shareIcon} alt="공유버튼" />
           </ShareButton>
         </Modal>
       </ModalWrap>
+      {toastMessage && (
+        <ToastMessage
+          message={toastMessage}
+          onClose={() => setToastMessage('')}
+        />
+      )}
     </div>
   );
 };

--- a/src/components/ui/GalleryModal.jsx
+++ b/src/components/ui/GalleryModal.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { fetchUserPositions } from '../../utils/getUserService';
+import OrigamiCanvas from '../../components/three/OrigamiCanvas';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import closeIcon from '../../assets/img/close.png';
@@ -28,17 +29,6 @@ const Modal = styled.div`
   background-color: #fff;
   padding: 80px;
   border-radius: 50px;
-`;
-
-const ModalImg = styled.div`
-  width: 300px;
-  height: 300px;
-  background-color: #e8e8e8;
-
-  img {
-    width: 100%;
-    height: auto;
-  }
 `;
 
 const ModalText = styled.h3`
@@ -108,9 +98,7 @@ const GalleryModal = ({ onClick, data }) => {
           <CloseButton onClick={onClick}>
             <img src={closeIcon} alt="닫는버튼" />
           </CloseButton>
-          <ModalImg>
-            <img src={selectedItem.thumbnail} alt="종이접기 이미지" />
-          </ModalImg>
+          <OrigamiCanvas positions={positions} />
           <ModalText>{selectedItem.nickname}</ModalText>
           <ShareButton>
             <img src={shareIcon} alt="공유버튼" />

--- a/src/components/ui/ToastMessage.jsx
+++ b/src/components/ui/ToastMessage.jsx
@@ -1,0 +1,45 @@
+import { useState, useEffect } from 'react';
+import styled from 'styled-components';
+
+const ToastWrap = styled.div`
+  opacity: ${({ show }) => (show ? 1 : 0)};
+  position: fixed;
+  bottom: ${({ show }) => (show ? '50px' : '-100px')};
+  left: 50%;
+  transform: translate(-50%, 0);
+  padding: 10px 50px;
+  background: rgba(0, 0, 0, 0.8);
+  color: white;
+  border-radius: 100px;
+  transition: all 0.5s ease;
+  z-index: 9999;
+`;
+
+const Message = styled.p`
+  font-size: 14px;
+`;
+
+const ToastMessage = ({ message, duration = 2000, onClose }) => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    if (message) {
+      setIsVisible(true);
+
+      const timeout = setTimeout(() => {
+        setIsVisible(false);
+        if (onClose) onClose();
+      }, duration);
+
+      return () => clearTimeout(timeout);
+    }
+  }, [message, duration, onClose]);
+
+  return (
+    <ToastWrap show={isVisible ? 1 : 0}>
+      <Message>{message}</Message>
+    </ToastWrap>
+  );
+};
+
+export default ToastMessage;

--- a/src/constants/toastMessage.js
+++ b/src/constants/toastMessage.js
@@ -1,0 +1,13 @@
+const TOAST_MESSAGE = {
+  SAME_POSITION: '🚨 마우스를 접을 곳으로 이동해 주세요',
+  NO_POINTMARKER: '🚨 꼭짓점이 접을 수 있는 선분에 닿아야 합니다',
+  NO_SELECTED_MODE: '🚨 시작할 모드를 선택해주세요!',
+  URL_COPY: '링크가 복사되었습니다 ✅',
+  NO_NICKNAME: '🚨 등록할 이름은 공백으로만 이루어질 수 없습니다!',
+  SUCCESS_SAVE: '공유가 완료되었습니다 ✅',
+  ERROR_SAVE: '🚨 사용자 정보 저장 중 오류가 발생했습니다',
+  ERROR_COPY: '🚨 URL 복사 중 오류가 발생했습니다',
+  ERROR_DEFAULT: '🚨 오류가 발생하였습니다',
+};
+
+export default TOAST_MESSAGE;

--- a/src/pages/GalleryPage.jsx
+++ b/src/pages/GalleryPage.jsx
@@ -1,11 +1,11 @@
 import { useState, useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { fetchAllUserDocuments } from '../utils/getUserService';
 import GalleryCard from '../components/ui/GalleryCard';
 import styled from 'styled-components';
 import Sidebar from '../components/ui/Sidebar';
 import GalleryModal from '../components/ui/GalleryModal';
 import arrowImage from '../assets/img/arrow.png';
-import { useSearchParams } from 'react-router-dom';
 
 const Main = styled.main`
   display: flex;
@@ -99,7 +99,6 @@ const GalleryPage = () => {
     setModalOpen(false);
 
     const newSearchParams = new URLSearchParams(searchParams);
-    console.log('newSearchParams', newSearchParams);
     newSearchParams.delete('id');
 
     setSearchParams(newSearchParams);
@@ -154,7 +153,9 @@ const GalleryPage = () => {
                 />
               ))}
             </GalleryListWrap>
-            {modalOpen && <GalleryModal onClick={changeCloseModal} />}
+            {modalOpen && (
+              <GalleryModal onClick={changeCloseModal} data={currentItems} />
+            )}
             <NextButton
               onClick={handleNextPage}
               disabled={currentPage === totalPages}

--- a/src/utils/copyURL.js
+++ b/src/utils/copyURL.js
@@ -1,0 +1,13 @@
+import TOAST_MESSAGE from '../constants/toastMessage';
+
+const copyURL = async () => {
+  const currentUrl = window.location.href;
+  try {
+    await navigator.clipboard.writeText(currentUrl);
+    return TOAST_MESSAGE.URL_COPY;
+  } catch (error) {
+    return TOAST_MESSAGE.ERROR_COPY;
+  }
+};
+
+export default copyURL;

--- a/src/utils/getUserService.js
+++ b/src/utils/getUserService.js
@@ -15,10 +15,10 @@ const fetchUserDocument = async id => {
 
 const fetchAllUserDocuments = async () => {
   try {
-    const querySnapshot = await getDocs(collection(db, 'users'));
+    const usersDoc = await getDocs(collection(db, 'users'));
     const allDocuments = [];
 
-    querySnapshot.docs.forEach(doc => {
+    usersDoc.docs.forEach(doc => {
       const data = doc.data();
       allDocuments.push({ id: doc.id, ...data });
     });


### PR DESCRIPTION
## 📍 주요 변경사항

- Gallery 페이지 모달창 3D 렌더링 로직 구현
- share 기능 구현

## 🔗 참고자료
<img width="500" alt="스크린샷 2024-09-30 오전 5 18 53" src="https://github.com/user-attachments/assets/5c3fcd52-4ee5-4f21-bad1-b415b9d2db86">

## 작업 내용(to-do list)
- [x] getUserpositions 함수 생성하여 해당 모달의 id 값으로 3D 좌표 가져오기
- [x] Canvas 구현
- [x] position 좌표 렌더링 기능 구현
- [x] three.js eslint 오류 해결
- [x] copyURL 함수 생성하여 해당 url 복사 기능 구현
- [x] ToastMessage 기능 구현
- [x] TOAST_MESSAGE 텍스트 저장

# 주의사항

- [x] PR 크기는 300-500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요.
- [x] 위 해당사항을 모두 완료 후 PR을 올려주세요.

# PR 전 체크리스트

- [x] 가장 최신 브랜치를 Pull 했습니다.
- [x] base 브랜치명을 확인했습니다.
- [x] 코드 컨벤션을 모두 확인했습니다.
- [x] 브랜치 명을 확인했습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 주의사항에 꼭 적어주세요!
- [x] 위 해당사항을 모두 완료 후 PR을 올려주세요.
