### PR TITLE
접기위해 선택된 두 점 표시 및 vector 저장 구현

### DIFF
--- a/src/atoms/foldAtom.js
+++ b/src/atoms/foldAtom.js
@@ -1,0 +1,4 @@
+import { atom } from 'jotai';
+
+export const isDraggingAtom = atom(false);
+export const selectedVerticesAtom = atom({ point1: null, point2: null });

--- a/src/atoms/index.js
+++ b/src/atoms/index.js
@@ -7,6 +7,8 @@ import {
   sceneAtom,
 } from './paperAtom';
 
+import { isDraggingAtom, selectedVerticesAtom } from './foldAtom';
+
 export {
   paperAtom,
   borderVerticesAtom,
@@ -14,4 +16,6 @@ export {
   cameraAtom,
   raycasterAtom,
   sceneAtom,
+  isDraggingAtom,
+  selectedVerticesAtom,
 };

--- a/src/components/three/BorderPoints.jsx
+++ b/src/components/three/BorderPoints.jsx
@@ -1,8 +1,13 @@
 import { useMemo } from 'react';
 import { useAtom } from 'jotai';
-import { borderVerticesAtom, closestVertexAtom } from '../../atoms';
+import {
+  borderVerticesAtom,
+  closestVertexAtom,
+  selectedVerticesAtom,
+  isDraggingAtom,
+} from '../../atoms';
 import { generateBorderPoints } from './utils/borderVerticesUtils';
-import { POINTS_MARKER_COLOR } from '../../constants/paper';
+import { POINTS_MARKER_COLOR, RED_MARKER_COLOR } from '../../constants/paper';
 import PointsMarker from './PointsMarker';
 
 export const findClickClosestVertex = (point, corners, pointsPerEdge = 9) => {
@@ -25,6 +30,8 @@ export const findClickClosestVertex = (point, corners, pointsPerEdge = 9) => {
 const BorderPoints = ({ corners, pointsPerEdge = 9, axisPoints }) => {
   const [, setBorderVertices] = useAtom(borderVerticesAtom);
   const [closestVertex] = useAtom(closestVertexAtom);
+  const [selectedVertices] = useAtom(selectedVerticesAtom);
+  const [isDragging] = useAtom(isDraggingAtom);
 
   useMemo(() => {
     const newBorderVertices = generateBorderPoints(corners, pointsPerEdge);
@@ -33,9 +40,19 @@ const BorderPoints = ({ corners, pointsPerEdge = 9, axisPoints }) => {
 
   return (
     <group>
-      {closestVertex && (
-        <PointsMarker position={closestVertex} color={POINTS_MARKER_COLOR} />
+      {isDragging && selectedVertices.point1 && (
+        <PointsMarker
+          position={selectedVertices.point1}
+          color={RED_MARKER_COLOR}
+        />
       )}
+      {closestVertex && (
+        <PointsMarker
+          position={closestVertex}
+          color={isDragging ? RED_MARKER_COLOR : POINTS_MARKER_COLOR}
+        />
+      )}
+
       {axisPoints && (
         <line>
           <bufferGeometry>


### PR DESCRIPTION
## 📍 주요 변경사항

**foldAtom.js**
-마우스 드래그 중인지 상태 저장하는 atom 추가 
```export const isDraggingAtom = atom(false);```
-마우스 클릭했을 때, 뗐을 때 가장 가까운 점의 Vector3 값을 저장하는 atom 추가
```export const selectedVerticesAtom = atom({ point1: null, point2: null });```
-마우스가 드래그 중일 때는 정점이 모두 붉은 색으로 변경됩니다.

저는 다음으로 접기 조건 충족 안됐을 때 토스트 메세지 뜨는 기능 구현하고있겠습니다.
두 점 정보 atom에 담고있으니 축 구하는 로직 구현하시면 될 것 같아요.

## 🔗 참고자료
![twoVertices](https://github.com/user-attachments/assets/c3dfea5f-24ac-4517-a392-37b98acc15c4)

# Concern

- 소희님께서 구현하신 드래그일 때 종이 돌아가는 것 멈추는 기능 오류 있을 때도 있는 것 같은데 확인해주세요! 

# 주의사항

- [x] PR 크기는 300-500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요.
- [x] 위 해당사항을 모두 완료 후 PR을 올려주세요.

# PR 전 체크리스트

- [x] 가장 최신 브랜치를 Pull 했습니다.
- [x] base 브랜치명을 확인했습니다.
- [x] 코드 컨벤션을 모두 확인했습니다.
- [x] 브랜치 명을 확인했습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 주의사항에 꼭 적어주세요!
- [x] 위 해당사항을 모두 완료 후 PR을 올려주세요.
