### PR TITLE
두 점의 좌표 전역상태로 저장 기능 구현

### DIFF
--- a/src/components/three/Paper.jsx
+++ b/src/components/three/Paper.jsx
@@ -18,10 +18,9 @@ import {
   updateBoundaryAndAxis,
   computeBoundaryPoints,
 } from './utils/computeBoundaryPoints';
-import { handlePointerEvent } from './utils/paperUtils';
 import { SEGMENT_NUM } from '../../constants/paper';
 
-const Paper = ({ position, setIsInteracting }) => {
+const Paper = ({ position }) => {
   const meshRef = useRef();
   const [axisPoints, setAxisPoints] = useState(null);
   const [paperVertices, setPaperVertices] = useState([]);
@@ -67,7 +66,6 @@ const Paper = ({ position, setIsInteracting }) => {
     }
 
     if (closestVertex) {
-      setIsInteracting(true);
       setIsDragging(true);
     }
   };
@@ -91,8 +89,6 @@ const Paper = ({ position, setIsInteracting }) => {
         setAxisPoints(updatedAxisPoints);
       }
     }
-
-    setIsInteracting(false);
     setIsDragging(false);
   };
 

--- a/src/components/three/PaperCanvas.jsx
+++ b/src/components/three/PaperCanvas.jsx
@@ -28,7 +28,6 @@ const CanvasContainer = styled.div`
 const PaperCanvas = () => {
   const containerRef = useRef();
   const [isInteracting, setIsInteracting] = useState(false);
-
   const [borderVertices] = useAtom(borderVerticesAtom);
   const [, setClosestVertex] = useAtom(closestVertexAtom);
   const [camera] = useAtom(cameraAtom);
@@ -47,6 +46,7 @@ const PaperCanvas = () => {
 
       if (mouse3DPoint) {
         const closestVertex = findClosestMesh(mouse3DPoint, borderVertices);
+
         setClosestVertex(closestVertex);
       } else {
         setClosestVertex(null);

--- a/src/components/three/PaperCanvas.jsx
+++ b/src/components/three/PaperCanvas.jsx
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import { useState, useRef, useCallback } from 'react';
+import { useRef, useCallback } from 'react';
 import { Canvas } from '@react-three/fiber';
 import { OrbitControls } from '@react-three/drei';
 import { useAtom } from 'jotai';
@@ -11,6 +11,7 @@ import {
   cameraAtom,
   raycasterAtom,
   sceneAtom,
+  isDraggingAtom,
 } from '../../atoms';
 import {
   getMousePositionIn3D,
@@ -27,12 +28,12 @@ const CanvasContainer = styled.div`
 
 const PaperCanvas = () => {
   const containerRef = useRef();
-  const [isInteracting, setIsInteracting] = useState(false);
   const [borderVertices] = useAtom(borderVerticesAtom);
   const [, setClosestVertex] = useAtom(closestVertexAtom);
   const [camera] = useAtom(cameraAtom);
   const [raycaster] = useAtom(raycasterAtom);
   const [scene] = useAtom(sceneAtom);
+  const [isDragging] = useAtom(isDraggingAtom);
 
   const handleMouseMove = useCallback(
     event => {
@@ -60,9 +61,9 @@ const PaperCanvas = () => {
       <Canvas onMouseMove={handleMouseMove}>
         <ambientLight intensity={0.5} />
         <directionalLight position={[1, 1, 1]} intensity={0.5} />
-        <Paper position={[0, 0, 0]} setIsInteracting={setIsInteracting} />
+        <Paper position={[0, 0, 0]} />
         <OrbitControls
-          enabled={!isInteracting}
+          enabled={!isDragging}
           enableDamping={true}
           dampingFactor={0.25}
           enableZoom={true}

--- a/src/components/three/utils/paperUtils.js
+++ b/src/components/three/utils/paperUtils.js
@@ -5,6 +5,7 @@ export const calculateMousePosition = event => {
   const mouse = new THREE.Vector2();
   mouse.x = (event.clientX / window.innerWidth) * 2 - 1;
   mouse.y = -(event.clientY / window.innerHeight) * 2 + 1;
+
   return mouse;
 };
 
@@ -17,7 +18,6 @@ export const getIntersectionPoint = (mouse, camera, raycaster, meshRef) => {
 export const handlePointerEvent = (
   event,
   setPoint,
-  logMessage,
   camera,
   raycaster,
   meshRef,


### PR DESCRIPTION
## 📍 주요 변경사항

- selectedVertices로 클릭한 점 전역상태로 저장
- handlePointerUp, handlePointerDown 함수 내 로직 수정

## 🔗 참고자료

<img width="1029" alt="스크린샷 2024-10-05 오후 7 37 13" src="https://github.com/user-attachments/assets/07359ce6-75c1-401e-ab88-8fef46d69762">

## 작업 내용(to-do list)

- [x] selectedVertices로 클릭한 점 전역상태로 저장
- [x] handlePointerUp, handlePointerDown 함수 내 로직 수정
- [x] 드래그 상태 전역상태로 저장

# 주의사항

- [x] PR 크기는 300-500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요.
- [x] 위 해당사항을 모두 완료 후 PR을 올려주세요.

# PR 전 체크리스트

- [x] 가장 최신 브랜치를 Pull 했습니다.
- [x] base 브랜치명을 확인했습니다.
- [x] 코드 컨벤션을 모두 확인했습니다.
- [x] 브랜치 명을 확인했습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 주의사항에 꼭 적어주세요!
- [x] 위 해당사항을 모두 완료 후 PR을 올려주세요.
