### PR TITLE
확장되는 축과 경계좌표와 겹치는 좌표 판별 로직 구현

### DIFF
--- a/src/atoms/index.js
+++ b/src/atoms/index.js
@@ -5,6 +5,7 @@ import {
   cameraAtom,
   raycasterAtom,
   sceneAtom,
+  axisPointsAtom,
 } from './paperAtom';
 
 import { isDraggingAtom, selectedVerticesAtom } from './foldAtom';
@@ -18,4 +19,5 @@ export {
   sceneAtom,
   isDraggingAtom,
   selectedVerticesAtom,
+  axisPointsAtom,
 };

--- a/src/atoms/paperAtom.js
+++ b/src/atoms/paperAtom.js
@@ -18,3 +18,4 @@ export const paperAtom = atom(() => {
 
 export const borderVerticesAtom = atom([]);
 export const closestVertexAtom = atom({});
+export const axisPointsAtom = atom(null);

--- a/src/components/three/Paper.jsx
+++ b/src/components/three/Paper.jsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useEffect } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import * as THREE from 'three';
 import { useThree } from '@react-three/fiber';
 import paperShaderMaterial from './utils/PaperShaderMaterial';
@@ -20,7 +20,7 @@ import {
 } from './utils/computeBoundaryPoints';
 import { SEGMENT_NUM } from '../../constants/paper';
 
-const Paper = ({ position }) => {
+const Paper = React.memo(() => {
   const meshRef = useRef();
   const [axisPoints, setAxisPoints] = useState(null);
   const [paperVertices, setPaperVertices] = useState([]);
@@ -36,6 +36,7 @@ const Paper = ({ position }) => {
   const [selectedVertices, setSelectedVertices] = useAtom(selectedVerticesAtom);
 
   const paperCorners = computeBoundaryPoints(paperVertices);
+  const paperPosition = [0, 0, 0];
 
   useEffect(() => {
     setCamera(camera);
@@ -99,7 +100,7 @@ const Paper = ({ position }) => {
   }, [selectedVertices]);
 
   return (
-    <group position={position}>
+    <group position={paperPosition}>
       <mesh
         ref={meshRef}
         onPointerDown={handlePointerDown}
@@ -119,6 +120,6 @@ const Paper = ({ position }) => {
       />
     </group>
   );
-};
+});
 
 export default Paper;

--- a/src/components/three/Paper.jsx
+++ b/src/components/three/Paper.jsx
@@ -12,17 +12,17 @@ import {
   closestVertexAtom,
   isDraggingAtom,
   selectedVerticesAtom,
+  axisPointsAtom,
 } from '../../atoms';
 import BorderPoints from './BorderPoints';
 import {
   updateBoundaryAndAxis,
   computeBoundaryPoints,
 } from './utils/computeBoundaryPoints';
-import { SEGMENT_NUM } from '../../constants/paper';
+import { SEGMENT_NUM, PAPER_POSITION } from '../../constants/paper';
 
 const Paper = React.memo(() => {
   const meshRef = useRef();
-  const [axisPoints, setAxisPoints] = useState(null);
   const [paperVertices, setPaperVertices] = useState([]);
   const [colors] = useAtom(paperAtom);
 
@@ -33,10 +33,10 @@ const Paper = React.memo(() => {
 
   const [, setIsDragging] = useAtom(isDraggingAtom);
   const [closestVertex] = useAtom(closestVertexAtom);
+  const [axisPoints, setAxisPoints] = useAtom(axisPointsAtom);
   const [selectedVertices, setSelectedVertices] = useAtom(selectedVerticesAtom);
 
   const paperCorners = computeBoundaryPoints(paperVertices);
-  const paperPosition = [0, 0, 0];
 
   useEffect(() => {
     setCamera(camera);
@@ -100,7 +100,7 @@ const Paper = React.memo(() => {
   }, [selectedVertices]);
 
   return (
-    <group position={paperPosition}>
+    <group position={PAPER_POSITION}>
       <mesh
         ref={meshRef}
         onPointerDown={handlePointerDown}

--- a/src/components/three/PaperCanvas.jsx
+++ b/src/components/three/PaperCanvas.jsx
@@ -61,7 +61,7 @@ const PaperCanvas = () => {
       <Canvas onMouseMove={handleMouseMove}>
         <ambientLight intensity={0.5} />
         <directionalLight position={[1, 1, 1]} intensity={0.5} />
-        <Paper position={[0, 0, 0]} />
+        <Paper />
         <OrbitControls
           enabled={!isDragging}
           enableDamping={true}

--- a/src/components/three/utils/computeBoundaryPoints.js
+++ b/src/components/three/utils/computeBoundaryPoints.js
@@ -79,13 +79,13 @@ export const calculateRotatedLine = (
     midpoint,
     rotatedDirection,
     boundaryPoints
-  ).add(new THREE.Vector3(0, 0, 0.01));
+  ).add(new THREE.Vector3(0, 0, 0.001));
 
   const endPoint = extendToBoundary(
     midpoint,
     rotatedDirection.negate(),
     boundaryPoints
-  ).add(new THREE.Vector3(0, 0, 0.01));
+  ).add(new THREE.Vector3(0, 0, 0.001));
 
   const geometry = new THREE.BufferGeometry().setFromPoints([
     startPoint,
@@ -125,15 +125,26 @@ const findIntersection = (midpoint, direction, boundaryPoints) => {
   let closestIntersection = null;
   let minDistance = Infinity;
 
+  const ray = new THREE.Ray(midpoint, direction);
+
   for (let i = 0; i < boundaryPoints.length; i++) {
     const currentPoint = boundaryPoints[i];
     const nextPoint = boundaryPoints[(i + 1) % boundaryPoints.length];
+    const intersectionPoint = new THREE.Vector3();
+
+    const result = ray.distanceSqToSegment(
+      currentPoint,
+      nextPoint,
+      intersectionPoint
+    );
+
+    if (result < minDistance) {
+      minDistance = result;
+      closestIntersection = intersectionPoint.clone();
+    }
   }
 
-  return (
-    closestIntersection ||
-    midpoint.clone().add(direction.clone().multiplyScalar(AXIS_BOUNDARY))
-  );
+  return closestIntersection;
 };
 
 export const updateBoundaryAndAxis = (

--- a/src/constants/paper.js
+++ b/src/constants/paper.js
@@ -20,3 +20,4 @@ export const DASH_SIZE = 0.02;
 export const Z_GAP = 0.02;
 export const FRAMES = 30;
 export const DIAMETER = Math.PI;
+export const PAPER_POSITION = [0, 0, 0];


### PR DESCRIPTION
## 📍 주요 변경사항

- Paper 컴포넌트 무한 리렌더링 방지하기위해 Props 제거 후 React.memo 적용
- findIntersection 함수 내 확장되는 축과 경계좌표와 겹치는 좌표 판별 로직 구현

## 🔗 참고자료

![Oct-06-2024 23-05-12](https://github.com/user-attachments/assets/37f40c33-38a3-4b5f-97e4-0a5ccf8ba048)

## 작업 내용(to-do list)

- [x] Paper 컴포넌트 무한 리렌더링 오류 해결
- [x] 확장되는 축과 경계좌표와 겹치는 좌표 판별 로직 구현

# 주의사항

- [x] PR 크기는 300-500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요.
- [x] 위 해당사항을 모두 완료 후 PR을 올려주세요.

# PR 전 체크리스트

- [x] 가장 최신 브랜치를 Pull 했습니다.
- [x] base 브랜치명을 확인했습니다.
- [x] 코드 컨벤션을 모두 확인했습니다.
- [x] 브랜치 명을 확인했습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 주의사항에 꼭 적어주세요!
- [x] 위 해당사항을 모두 완료 후 PR을 올려주세요.
