### PR TITLE
접힌 면을 판별하여 펼치기 기능 구현

### DIFF
--- a/src/components/three/Paper.jsx
+++ b/src/components/three/Paper.jsx
@@ -190,14 +190,7 @@ const Paper = React.memo(({ setToastMessage }) => {
     ]);
 
     setBorderVertices([...foldedVertices, ...newBorderVertices]);
-  }, [
-    axisPoints,
-    paperAllPositions,
-    selectedVertices,
-    camera,
-    meshRef,
-    // borderVertices,
-  ]);
+  }, [axisPoints, paperAllPositions, selectedVertices, camera, meshRef]);
 
   return (
     <group position={PAPER_POSITION}>

--- a/src/constants/guide.js
+++ b/src/constants/guide.js
@@ -1,0 +1,252 @@
+const GUIDE_IMAGES = {
+  puppy: [
+    './src/assets/img/guide/puppy-guide1.png',
+    './src/assets/img/guide/puppy-guide2.png',
+    './src/assets/img/guide/puppy-guide3.png',
+    './src/assets/img/guide/puppy-guide4.png',
+    './src/assets/img/guide/puppy-guide5.png',
+    './src/assets/img/guide/puppy-guide6.png',
+    './src/assets/img/guide/puppy-guide7.png',
+  ],
+  plane: [
+    './src/assets/img/guide/plane-guide1.png',
+    './src/assets/img/guide/plane-guide2.png',
+    './src/assets/img/guide/plane-guide3.png',
+    './src/assets/img/guide/plane-guide4.png',
+    './src/assets/img/guide/plane-guide5.png',
+    './src/assets/img/guide/plane-guide6.png',
+    './src/assets/img/guide/plane-guide7.png',
+    './src/assets/img/guide/plane-guide8.png',
+    './src/assets/img/guide/plane-guide9.png',
+    './src/assets/img/guide/plane-guide10.png',
+    './src/assets/img/guide/plane-guide11.png',
+    './src/assets/img/guide/plane-guide12.png',
+  ],
+};
+
+const GUIDE_STEPS = {
+  puppy: [
+    {
+      points: [
+        { x: 0, y: 2.1, z: 0 },
+        { x: 0, y: -2.1, z: 0 },
+      ],
+      axis: null,
+      unfold: false,
+      singleSide: false,
+    },
+    {
+      points: [
+        { x: 2.1, y: 0, z: 0 },
+        { x: -2.1, y: 0, z: 0 },
+      ],
+      axis: null,
+      unfold: false,
+      singleSide: false,
+    },
+    {
+      points: [],
+      axis: null,
+      unfold: true,
+      singleSide: false,
+    },
+    {
+      points: [
+        { x: -1.7, y: 0, z: 0 },
+        { x: -1.2, y: -0.85, z: 0 },
+      ],
+      axis: null,
+      unfold: false,
+      singleSide: false,
+    },
+    {
+      points: [
+        { x: 1.7, y: 0, z: 0 },
+        { x: 1.2, y: -0.85, z: 0 },
+      ],
+      axis: null,
+      unfold: false,
+      singleSide: false,
+    },
+    {
+      points: [
+        { x: 0, y: -2.1, z: 0 },
+        { x: 0, y: -1.4, z: 0 },
+      ],
+      axis: null,
+      unfold: false,
+      singleSide: false,
+    },
+    {
+      points: [
+        { x: 0, y: -2.1, z: 0 },
+        { x: 0, y: -1.4, z: 0 },
+      ],
+      axis: null,
+      unfold: false,
+      singleSide: false,
+    },
+    {
+      points: [
+        { x: -1.8, y: 0, z: 0 },
+        { x: 2.1, y: 0, z: 0 },
+      ],
+      axis: null,
+      unfold: false,
+      singleSide: false,
+    },
+  ],
+  plane: [
+    {
+      points: [
+        { x: 0, y: 1.5, z: 0 },
+        { x: 0, y: -1.5, z: 0 },
+      ],
+      axis: null,
+      unfold: false,
+      singleSide: false,
+    },
+    {
+      points: [],
+      axis: null,
+      unfold: true,
+      singleSide: false,
+    },
+    {
+      points: [
+        { x: -1.5, y: 1.5, z: 0 },
+        { x: 0, y: 0, z: 0 },
+      ],
+      axis: null,
+      unfold: false,
+      singleSide: false,
+    },
+    {
+      points: [
+        { x: -1.5, y: -1.5, z: 0 },
+        { x: 0, y: 0, z: 0 },
+      ],
+      axis: null,
+      unfold: false,
+      singleSide: false,
+    },
+    {
+      points: [
+        { x: 0, y: 1.5, z: 0 },
+        { x: 0.62, y: 0.00019991115391304604, z: 0 },
+      ],
+      axis: null,
+      unfold: false,
+      singleSide: false,
+    },
+    {
+      points: [
+        { x: 0, y: -1.5, z: 0 },
+        { x: 0.62, y: 0.00019991115391304604, z: 0 },
+      ],
+      axis: null,
+      unfold: false,
+      singleSide: false,
+    },
+    {
+      points: [
+        { x: -1.5, y: 0, z: 0 },
+        { x: -1, y: 0, z: 0 },
+      ],
+      axis: null,
+      unfold: false,
+      singleSide: false,
+    },
+    {
+      points: [
+        {
+          x: 0.6159830537825293,
+          y: -0.8763932215130115,
+          z: 0,
+        },
+        {
+          x: 0.6159830537825293,
+          y: 0.8763932215130115,
+          z: 0,
+        },
+      ],
+      axis: null,
+      unfold: false,
+      singleSide: false,
+    },
+    {
+      points: [
+        {
+          x: 0.3198644103773862,
+          y: 0.7579457641509544,
+          z: 0,
+        },
+        {
+          x: 0.48,
+          y: 0,
+          z: 0,
+        },
+      ],
+      axis: null,
+      unfold: false,
+      singleSide: true,
+    },
+    {
+      points: [
+        {
+          x: 0.3198644103773862,
+          y: 0.7579457641509544,
+          z: 0,
+        },
+        {
+          x: 0.48,
+          y: 0,
+          z: 0,
+        },
+      ],
+      axis: null,
+      unfold: false,
+      singleSide: true,
+    },
+    {
+      points: [],
+      axis: {
+        startPoint: { x: 0.3198644103773862, y: 0.7579457641509544 },
+        endPoint: {
+          x: 0.48,
+          y: 0,
+        },
+      },
+      unfold: true,
+      singleSide: true,
+    },
+    {
+      points: [],
+      axis: {
+        startPoint: { x: 0.3198644103773862, y: 0.7579457641509544 },
+        endPoint: {
+          x: 0.48,
+          y: 0,
+        },
+      },
+      unfold: true,
+      singleSide: true,
+    },
+    {
+      points: [],
+      axis: {
+        startPoint: { x: 0.3198644103773862, y: 0.7579457641509544 },
+        endPoint: {
+          x: 0.48,
+          y: 0,
+        },
+      },
+      unfold: false,
+      singleSide: true,
+    },
+  ],
+};
+
+const CHUNK_SIZE = 999;
+
+export { GUIDE_IMAGES, GUIDE_STEPS, CHUNK_SIZE };

--- a/src/utils/rotateSelectedVertices.js
+++ b/src/utils/rotateSelectedVertices.js
@@ -1,0 +1,119 @@
+import * as THREE from 'three';
+import { Z_GAP } from '../constants/paper';
+import { mode, nowStep } from '../constants/guide';
+
+const rotateVector = (vector, pivot, quaternion) => {
+  vector.sub(pivot);
+  vector.applyQuaternion(quaternion);
+  vector.add(pivot);
+  return vector;
+};
+
+const updateVertexZPosition = (positionAttribute, selectedVertices) => {
+  for (let i = 0; i < positionAttribute.count; i++) {
+    if (selectedVertices.has(i)) {
+      const z = positionAttribute.getZ(i);
+      if (z !== 0) {
+        const zAdjustment =
+          (mode === 'puppy' && nowStep === 3) || nowStep === 11
+            ? Z_GAP * 2
+            : Z_GAP;
+        positionAttribute.setZ(i, z < 0 ? z + zAdjustment : z - zAdjustment);
+      }
+    }
+  }
+  positionAttribute.needsUpdate = true;
+};
+
+const rotateSelectedVertices = (
+  positionAttribute,
+  selectedVertices,
+  totalRotation,
+  frames,
+  clockwise,
+  rotatedData
+) => {
+  const stepAngle = (totalRotation / frames) * (clockwise ? 1 : -1);
+  let currentFrame = 0;
+
+  const performRotation = () => {
+    const { startPoint, endPoint } = rotatedData;
+
+    if (startPoint && endPoint) {
+      const direction = new THREE.Vector3()
+        .subVectors(endPoint, startPoint)
+        .normalize();
+      const pivot = new THREE.Vector3()
+        .addVectors(startPoint, endPoint)
+        .multiplyScalar(0.5);
+      const unfoldQuaternion = new THREE.Quaternion().setFromAxisAngle(
+        direction,
+        stepAngle
+      );
+
+      const positionArray = positionAttribute.array;
+      const itemSize = positionAttribute.itemSize;
+
+      for (let i = 0; i < positionAttribute.count; i++) {
+        if (selectedVertices.has(i)) {
+          const index = i * itemSize;
+          const vector = new THREE.Vector3(
+            positionArray[index],
+            positionArray[index + 1],
+            positionArray[index + 2]
+          );
+
+          const rotatedVector = rotateVector(vector, pivot, unfoldQuaternion);
+
+          positionArray[index] = rotatedVector.x;
+          positionArray[index + 1] = rotatedVector.y;
+          positionArray[index + 2] = rotatedVector.z;
+        }
+      }
+      positionAttribute.needsUpdate = true;
+    }
+
+    currentFrame++;
+    if (currentFrame < frames) {
+      requestAnimationFrame(performRotation);
+    } else {
+      updateVertexZPosition(positionAttribute, selectedVertices);
+    }
+  };
+
+  performRotation();
+};
+
+const findAndSelectClosestVertices = (
+  positions,
+  positionAttribute,
+  selectedVertices
+) => {
+  const positionArray = positionAttribute.array;
+  const itemSize = positionAttribute.itemSize;
+
+  positions.forEach(target => {
+    let minDistance = Infinity;
+    let closestVertexIndex = -1;
+
+    for (let i = 0; i < positionAttribute.count; i++) {
+      const index = i * itemSize;
+
+      const dx = target.x - positionArray[index];
+      const dy = target.y - positionArray[index + 1];
+      const dz = target.z - positionArray[index + 2];
+      const distance = dx * dx + dy * dy + dz * dz;
+
+      if (distance < minDistance) {
+        minDistance = distance;
+        closestVertexIndex = i;
+      }
+    }
+
+    if (closestVertexIndex !== -1) {
+      selectedVertices.add(closestVertexIndex);
+    }
+  });
+};
+
+export { rotateSelectedVertices, findAndSelectClosestVertices };


### PR DESCRIPTION
## 📍 주요 변경사항

- 접힌 면을 클릭 시 rotateSelectedVertices.ts handleFoldedMeshClick의 함수를 통해 접힌면인지 판단합니다.
- rotateSelectedVertices의 함수를 통해 접힌 면을 다시 펼칩니다.

## 🔗 참고자료

![화면 기록 2024-10-15 오후 8 56 27](https://github.com/user-attachments/assets/1dbca3ae-dd05-41fa-a483-25b4c3bf3110)


# 주의사항

- [x] PR 크기는 300-500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요.
- [x] 위 해당사항을 모두 완료 후 PR을 올려주세요.

# PR 전 체크리스트

- [x] 가장 최신 브랜치를 Pull 했습니다.
- [x] base 브랜치명을 확인했습니다.
- [x] 코드 컨벤션을 모두 확인했습니다.
- [x] 브랜치 명을 확인했습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 주의사항에 꼭 적어주세요!
- [x] 위 해당사항을 모두 완료 후 PR을 올려주세요.
